### PR TITLE
Update UT3Hoverboard.uc

### DIFF
--- a/Classes/UT3Hoverboard.uc
+++ b/Classes/UT3Hoverboard.uc
@@ -1011,7 +1011,7 @@ defaultproperties
     CrosshairTexture=Texture'ONSInterface-TX.MineLayerReticle' //Texture'ONSInterface-TX.tankBarrelAligned'
     VehicleIcon=(Material=Texture'AS_FX_TX.HUD.TrackedVehicleIcon',X=0,Y=0,SizeX=64,SizeY=64)
 
-    bTeamLocked=True
+    bTeamLocked=False
     bZeroPCRotOnEntry=false
     bSetPCRotOnPossess=false
     bSpecialHUD=True


### PR DESCRIPTION
Fix team lock problem blue has, I tested this in-game and it works but I think it removes team lock from the hoverboard completely but as it's a weapon spawn and not a vehicle spawn on the field not much of an issue maybe?