### PR TITLE
UT3 Scorpion Fire Damage Degrade Closer to UT3

### DIFF
--- a/Classes/UT3Scorpion.uc
+++ b/Classes/UT3Scorpion.uc
@@ -632,6 +632,7 @@ defaultproperties
     //IdleSound=sound'UT3Vehicles.SCORPION.ScorpionEngine'
     StartUpSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Start01'
     ShutDownSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Stop01'
+    DamagedEffectFireDamagePerSec=0.95 //0.75 is UT2004 default
     RanOverDamageType=class'DamTypeRVRoadkill'
     CrushedDamageType=class'DamTypeRVPancake'
     SelfDestructDamageType=class'UT3ScorpionSDDamage'


### PR DESCRIPTION
In UT3 vehicles degrade from fire damage much quicker than UT2004, this value seems to be a close match