### PR TITLE
UT3 Scorpion Damage Phases Timing Closer to UT3

### DIFF
--- a/Classes/UT3Scorpion.uc
+++ b/Classes/UT3Scorpion.uc
@@ -633,7 +633,7 @@ defaultproperties
     StartUpSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Start01'
     ShutDownSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Stop01'
     DamagedEffectHealthSmokeFactor=0.65 //0.5
-	DamagedEffectHealthFireFactor=0.37 //0.25
+    DamagedEffectHealthFireFactor=0.373 //0.25
     RanOverDamageType=class'DamTypeRVRoadkill'
     CrushedDamageType=class'DamTypeRVPancake'
     SelfDestructDamageType=class'UT3ScorpionSDDamage'

--- a/Classes/UT3Scorpion.uc
+++ b/Classes/UT3Scorpion.uc
@@ -632,6 +632,8 @@ defaultproperties
     //IdleSound=sound'UT3Vehicles.SCORPION.ScorpionEngine'
     StartUpSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Start01'
     ShutDownSound=sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_Stop01'
+    DamagedEffectHealthSmokeFactor=0.65 //0.5
+	DamagedEffectHealthFireFactor=0.37 //0.25
     RanOverDamageType=class'DamTypeRVRoadkill'
     CrushedDamageType=class'DamTypeRVPancake'
     SelfDestructDamageType=class'UT3ScorpionSDDamage'


### PR DESCRIPTION
Smoke now starts at exactly the same health remaining as UT3 which is 192 health (if shot only by an enforcer from full 300)
Fire starts at 109 which is as close as I could get it, in UT3 it starts at 111