### PR TITLE
UT3 Hellbender Driver Turret Movement Closer to UT3

### DIFF
--- a/Classes/UT3HellbenderSideGun.uc
+++ b/Classes/UT3HellbenderSideGun.uc
@@ -52,6 +52,6 @@ defaultproperties
     AltFireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BeamFire01'
     PitchUpLimit=16000
     PitchDownLimit=59200
-	bInstantRotation=False
+    bInstantRotation=False
     ProjectileClass = class'UT3HBShockBall'
 }

--- a/Classes/UT3HellbenderSideGun.uc
+++ b/Classes/UT3HellbenderSideGun.uc
@@ -50,5 +50,8 @@ defaultproperties
     WeaponFireAttachmentBone=SecondaryTurretBarrel
     FireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BallFire01'
     AltFireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BeamFire01'
+    PitchUpLimit=16000
+    PitchDownLimit=59200
+	bInstantRotation=False
     ProjectileClass = class'UT3HBShockBall'
 }

--- a/Classes/UT3HellbenderSideGun.uc
+++ b/Classes/UT3HellbenderSideGun.uc
@@ -50,7 +50,7 @@ defaultproperties
     WeaponFireAttachmentBone=SecondaryTurretBarrel
     FireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BallFire01'
     AltFireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BeamFire01'
-    PitchUpLimit=16000
+    PitchUpLimit=9600  //16000 is about what UT3 is but we don't have UT3's camera collision meaning we see under and through the Hellbender in UT2004
     PitchDownLimit=59200
     bInstantRotation=False
     ProjectileClass = class'UT3HBShockBall'


### PR DESCRIPTION
In UT3 on PC (not PS3 though) the turrets don't have instant turn and for the driver turret it can shoot straight up into the sky but has limited pitch on firing low, these values feel the closet to this