### PR TITLE
UT3 Hellbender No Impact Damage Discussion

### DIFF
--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -420,6 +420,9 @@ defaultproperties
     IdleSound=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_EngineIdle01'
     StartUpSound=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_EngineStart01'
     ShutDownSound=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_EngineStop01'
+    DamagedEffectHealthSmokeFactor=0.65 //0.5
+	DamagedEffectHealthFireFactor=0.37 //0.25
+	DamagedEffectFireDamagePerSec=0.95 //0.75
     EntryRadius=300.000000
     TPCamWorldOffset=(Z=200.000000)
     MomentumMult=1.000000

--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -421,8 +421,8 @@ defaultproperties
     StartUpSound=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_EngineStart01'
     ShutDownSound=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_EngineStop01'
     DamagedEffectHealthSmokeFactor=0.65 //0.5
-	DamagedEffectHealthFireFactor=0.37 //0.25
-	DamagedEffectFireDamagePerSec=0.95 //0.75
+    DamagedEffectHealthFireFactor=0.39 //0.25
+    DamagedEffectFireDamagePerSec=0.95 //0.75
     EntryRadius=300.000000
     TPCamWorldOffset=(Z=200.000000)
     MomentumMult=1.000000


### PR DESCRIPTION
Smoke starts at same health but on fire is off by 10 points of health, the damage per sec should be consistent across every vehicle but for some reason the UT3 Hellbender in UT2004 is not taking ANY fire damage