### PR TITLE
UT3 Hellbender Rear Turret Closer to UT3

### DIFF
--- a/Classes/UT3HellbenderRearGun.uc
+++ b/Classes/UT3HellbenderRearGun.uc
@@ -156,8 +156,8 @@ defaultproperties
     FireSoundClass=sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_TurretFire01'
     //BeamEffectClass=class'ShockBeamEffect'//'ONSChargeBeamEffect'
     FireInterval=0.5
-    DamageMin=180
-    DamageMax=180
+    DamageMin=85 //180
+    DamageMax=85 //180
     Momentum=75000
     MaxHoldTime=3.0
     //MinDamageScale=1.0
@@ -169,5 +169,6 @@ defaultproperties
     ChargingSound=None
     ChargedLoop=None
     bHoldingFire=True
+    bInstantRotation=False
 }
 

--- a/Classes/UT3HellbenderRearGun.uc
+++ b/Classes/UT3HellbenderRearGun.uc
@@ -156,8 +156,8 @@ defaultproperties
     FireSoundClass=sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_TurretFire01'
     //BeamEffectClass=class'ShockBeamEffect'//'ONSChargeBeamEffect'
     FireInterval=0.5
-    DamageMin=85 //180
-    DamageMax=85 //180
+    DamageMin=120 //180
+    DamageMax=120 //180
     Momentum=75000
     MaxHoldTime=3.0
     //MinDamageScale=1.0


### PR DESCRIPTION
In UT3 the Hellbender turrets don't turn instantly on PC and I've gotten consistent 85 damage to every vehicle I've shot with the rear turret