### PR TITLE
UT3 Hellbender Drawscale Discussion

### DIFF
--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -432,7 +432,7 @@ defaultproperties
     SoundVolume=255
     TransRatio=0.18 //0.11
     
-	DrawScale=0.9
+    DrawScale=0.9
     
     CollisionRadius=219
     HeadlightCoronaOffset(0)=(X=68.5,Y=24.5,Z=47.5) //(X=77.5,Y=27.5,Z=52.5)
@@ -442,10 +442,10 @@ defaultproperties
     HeadlightCoronaMaterial=Material'EmitterTextures.Flares.EFlareOY'
     HeadlightCoronaMaxSize=82
 
-	HeadlightProjectorOffset=(X=78.0,Y=0,Z=50.5) //(X=82.5,Y=0,Z=55.5)
-	HeadlightProjectorRotation=(Yaw=0,Pitch=-1000,Roll=0)
-	HeadlightProjectorMaterial=Texture'VMVehicles-TX.NewPRVGroup.PRVProjector'
-	HeadlightProjectorScale=0.40 //0.65
+    HeadlightProjectorOffset=(X=78.0,Y=0,Z=50.5) //(X=82.5,Y=0,Z=55.5)
+    HeadlightProjectorRotation=(Yaw=0,Pitch=-1000,Roll=0)
+    HeadlightProjectorMaterial=Texture'VMVehicles-TX.NewPRVGroup.PRVProjector'
+    HeadlightProjectorScale=0.40 //0.65
     //HeadlightProjectorMaterial=None
 
     BrakeLightOffset(0)=(X=-124.5,Y=36.5,Z=58) //(X=-137.5,Y=42.5,Z=64)

--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -428,20 +428,27 @@ defaultproperties
     VehiclePositionString="in a Hellbender"
     VehicleNameString="UT3 Hellbender"
     HornSounds(0)=Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_Horn01'
-    GroundSpeed=700.000000
+    GroundSpeed=800.000000 //700
     SoundVolume=255
-
-    DrawScale=1.0
+    TransRatio=0.18 //0.11
+    
+	DrawScale=0.9
+    
     CollisionRadius=219
-    HeadlightCoronaOffset(0)=(X=77.5,Y=27.5,Z=52.5)
-    HeadlightCoronaOffset(1)=(X=77.5,Y=-27.5,Z=52.5)
-    HeadlightCoronaOffset(2)=(X=77.5,Y=25,Z=41)
-    HeadlightCoronaOffset(3)=(X=77.5,Y=-25,Z=41)
+    HeadlightCoronaOffset(0)=(X=68.5,Y=24.5,Z=47.5) //(X=77.5,Y=27.5,Z=52.5)
+    HeadlightCoronaOffset(1)=(X=68.5,Y=-24.5,Z=47.5)
+    HeadlightCoronaOffset(2)=(X=68.5,Y=22,Z=38) //(X=77.5,Y=-25,Z=41)
+    HeadlightCoronaOffset(3)=(X=68.5,Y=-22,Z=38)
     HeadlightCoronaMaterial=Material'EmitterTextures.Flares.EFlareOY'
-    HeadlightCoronaMaxSize=94
-    HeadlightProjectorMaterial=None
+    HeadlightCoronaMaxSize=82
 
-    BrakeLightOffset(0)=(X=-137.5,Y=42.5,Z=64)
-    BrakeLightOffset(1)=(X=-137.5,Y=-42.5,Z=64)
+	HeadlightProjectorOffset=(X=78.0,Y=0,Z=50.5) //(X=82.5,Y=0,Z=55.5)
+	HeadlightProjectorRotation=(Yaw=0,Pitch=-1000,Roll=0)
+	HeadlightProjectorMaterial=Texture'VMVehicles-TX.NewPRVGroup.PRVProjector'
+	HeadlightProjectorScale=0.40 //0.65
+    //HeadlightProjectorMaterial=None
+
+    BrakeLightOffset(0)=(X=-124.5,Y=36.5,Z=58) //(X=-137.5,Y=42.5,Z=64)
+    BrakeLightOffset(1)=(X=-124.5,Y=-36.5,Z=58)
     BrakeLightMaterial=Material'EpicParticles.FlickerFlare'
 }

--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -343,6 +343,7 @@ defaultproperties
         KLinearDamping=0.05
         KAngularDamping=0.05
         KImpactThreshold=500
+        kMaxSpeed=1050.0
         bKNonSphericalInertia=True
         bHighDetailOnly=False
         bClientOnly=False

--- a/Classes/UT3Hellbender.uc
+++ b/Classes/UT3Hellbender.uc
@@ -443,7 +443,6 @@ defaultproperties
     HeadlightCoronaMaxSize=82
 
     HeadlightProjectorOffset=(X=78.0,Y=0,Z=50.5) //(X=82.5,Y=0,Z=55.5)
-    HeadlightProjectorRotation=(Yaw=0,Pitch=-1000,Roll=0)
     HeadlightProjectorMaterial=Texture'VMVehicles-TX.NewPRVGroup.PRVProjector'
     HeadlightProjectorScale=0.40 //0.65
     //HeadlightProjectorMaterial=None


### PR DESCRIPTION
First off I was wrong on DrawScale as my preferred character model is apparently an inch or more taller than a normal UT2004 model so using a normal UT2004 model a DrawScale of .9 looks closer, I've done my best to tweak the coronas to work with the smaller size.

Ground Speed according to UnCode is 800 but the max that can be achieved is 1050, TransRatio (assuming I understand it) has been increased to give acceleration closer to UT3 which is quite fast and probably still faster (assuming this is what TransRatio is)

MaxBrakeTorque of at least 30 is needed to come close to replicating how easily the Hellbender in UT3 can stop but in UT2004 it causes it to be lifted off the back wheels to the point it's bottom up so can't do that yet.

Whew a lot of testing and tweaking today....it's now 1:28 AM and I will probably be in bed until somewhere after 9 AM at least so don't expect my usual snappy replies....good night :)