### PR TITLE
UT3 Raptor Impact Damage Closer to UT3

### DIFF
--- a/Classes/UT3Raptor.uc
+++ b/Classes/UT3Raptor.uc
@@ -315,6 +315,7 @@ defaultproperties
     IdleSound = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_EngineLoop01';
     StartUpSound = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_Start01';
     ShutDownSound = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_Stop01';
+    ImpactDamageMult = 0.00003 //0.0003
     ImpactDamageSounds(0) = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_Collide01';
     ImpactDamageSounds(1) = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_Collide02';
     ImpactDamageSounds(2) = Sound'UT3A_Vehicle_Raptor.Sounds.A_Vehicle_Raptor_Collide01';


### PR DESCRIPTION
In UT3 the Raptor (and all vehicles in general) takes a lot less impact damage from hitting objects such as walls.   This value seems to get it closer to that, in UT3 skirting the ground doesn't damage the Raptor and now it won't happen in UT2004 either.  Flying almost full speed into a wall will still do 1-4 damage though (especially sideways it seemed) which is about what UT3 is.