### PR TITLE
UT3 Hellfire SPMA Camera Size Fix

### DIFF
--- a/Classes/UT3HellfireSPMACamera.uc
+++ b/Classes/UT3HellfireSPMACamera.uc
@@ -333,7 +333,8 @@ defaultproperties
     CVScale = 1.0
     MaxTargetRange = 10240.0
     Speed = 4000.0
-
+    DrawScale=0.3
+    AmbientSound      = Sound'UT3SPMA.SPMACameraAmbient'
     ImpactSound       = Sound'UT3SPMA.SPMAShellFragmentExplode'
     bOrientToVelocity = True
     bAlwaysRelevant   = True


### PR DESCRIPTION
In UT3 the camera is fairly small, this probably isn't exact but it shouldn't be far off, also according to the sound files there should be this ambient sound but I haven't been able to get it to work so it seems to do nothing but I believe this is where it goes.

The explosion size is still large, I haven't found how to scale it down yet but in UT3 it's about the same size as the camera.