### PR TITLE
UT3 Hellfire SPMA Headlights Adjustment

### DIFF
--- a/Classes/UT3HellfireSPMA.uc
+++ b/Classes/UT3HellfireSPMA.uc
@@ -929,8 +929,8 @@ defaultproperties
     DriverDamageMult = 0.0
     TreadVelocityScale = 30.0
 
-    HeadlightCoronaOffset(0)=(X=195,Y=85,Z=70)
-    HeadlightCoronaOffset(1)=(X=195,Y=-85,Z=70)
+    HeadlightCoronaOffset(0)=(X=213,Y=85,Z=43) //(X=195,Y=85,Z=70)
+    HeadlightCoronaOffset(1)=(X=213,Y=-85,Z=43) //(X=195,Y=-85,Z=70)
     HeadlightCoronaMaterial=Material'EmitterTextures.Flares.EFlareOY'
     HeadlightCoronaMaxSize=75
     HeadlightProjectorMaterial=None

--- a/Classes/UT3HellfireSPMA.uc
+++ b/Classes/UT3HellfireSPMA.uc
@@ -931,7 +931,8 @@ defaultproperties
 
     HeadlightCoronaOffset(0)=(X=213,Y=85,Z=43) //(X=195,Y=85,Z=70)
     HeadlightCoronaOffset(1)=(X=213,Y=-85,Z=43) //(X=195,Y=-85,Z=70)
-    HeadlightCoronaMaterial=Material'EmitterTextures.Flares.EFlareOY'
+    HeadlightCoronaMaterial=None
+    //HeadlightCoronaMaterial=Material'EmitterTextures.Flares.EFlareOY'
     HeadlightCoronaMaxSize=75
     HeadlightProjectorMaterial=None
 


### PR DESCRIPTION
We've got a slight problem with the headlights, they are meant to come from the wheel plates which turn and change position while moving forward or backward causing floating headlights....I'm guessing there isn't a way to fix this so the question is which do we want, headlights that are lined up when the vehicle is sitting still (probably best considering SPMA is usually deployed when you see it) or do we want them to line up while moving forward?  These values are for sitting still, I haven't come up with ones for moving yet but will if I need to.