### PR TITLE
UT3 Hellfire SPMA Handling Closer to UT3

### DIFF
--- a/Classes/UT3HellfireSPMA.uc
+++ b/Classes/UT3HellfireSPMA.uc
@@ -928,6 +928,12 @@ defaultproperties
     bDrawDriverInTP = false
     DriverDamageMult = 0.0
     TreadVelocityScale = 30.0
+    SteerSpeed=40 //110
+	TurnDamping=50 //35
+	bHasHandbrake=False //true
+	ChangeUpPoint=90000
+    MomentumMult=0.3 //2.0
+    bDoStuntInfo=False //true
 
     HeadlightCoronaOffset(0)=(X=195,Y=85,Z=70)
     HeadlightCoronaOffset(1)=(X=195,Y=-85,Z=70)


### PR DESCRIPTION
Some tweaks to make it handle more like UT3, I managed to get the speed to feel exactly like UT3 which I'm not sure we want because it's VERY VERY slow and UT2004 maps are (or seem) larger than UT3, and while I haven't tried it, it would probably take more than 3 minutes to cross Torlan with this speed.

In UT3 you can't do the handbrake turn, despite setting it to false it still happens in UT2004 and I haven't found a way to stop it yet.