### PR TITLE
UT3 Hellfire SPMA Damage Phases Closer to UT3

### DIFF
--- a/Classes/UT3HellfireSPMA.uc
+++ b/Classes/UT3HellfireSPMA.uc
@@ -925,8 +925,8 @@ defaultproperties
     StartUpSound   = Sound'UT3SPMA.SPMAEngineStart'
     ShutDownSound  = Sound'UT3SPMA.SPMAEngineStop'
     DamagedEffectHealthSmokeFactor=0.65 //0.5
-	DamagedEffectHealthFireFactor=0.37 //0.25
-	DamagedEffectFireDamagePerSec=0.95 //0.75
+    DamagedEffectHealthFireFactor=0.39 //0.25
+    DamagedEffectFireDamagePerSec=0.95 //0.75
 
     bDrawDriverInTP = false
     DriverDamageMult = 0.0

--- a/Classes/UT3HellfireSPMA.uc
+++ b/Classes/UT3HellfireSPMA.uc
@@ -924,6 +924,9 @@ defaultproperties
     IdleSound      = Sound'UT3SPMA.SPMAEngineIdle'
     StartUpSound   = Sound'UT3SPMA.SPMAEngineStart'
     ShutDownSound  = Sound'UT3SPMA.SPMAEngineStop'
+    DamagedEffectHealthSmokeFactor=0.65 //0.5
+	DamagedEffectHealthFireFactor=0.37 //0.25
+	DamagedEffectFireDamagePerSec=0.95 //0.75
 
     bDrawDriverInTP = false
     DriverDamageMult = 0.0


### PR DESCRIPTION
Smoke started at exactly 518 hp on both games but on fire started at 313 in UT3 and 296 in UT2004....and like the Hellbender fire damage over time doesn't seem to be happening no matter what value is used.