### PR TITLE
UT3 Scorpion 32 Bit Sound Difference Fix

### DIFF
--- a/Classes/UT3Scorpion.uc
+++ b/Classes/UT3Scorpion.uc
@@ -239,7 +239,7 @@ function Boost()
     {
         //log("UT3: Boosting!");
         BoostRechargeCounter=0;
-        PlaySound(BoostSound, SLOT_Misc, 128,,,64); //Boost sound Pitch 160
+        PlaySound(BoostSound, SLOT_Misc, 128,,,); //Boost sound Pitch 160
         bBoost = true;
         BoostCount--;
         SpeedAtBoost = Velocity dot Vector(Rotation);
@@ -348,7 +348,7 @@ function bool KDriverLeave(bool bForceLeave)
         && (Velocity dot Vector(Rotation) >= MinEjectSpeed))
     {
         bImminentDestruction = true;
-        PlaySound(BoostReadySound, SLOT_Misc, 128,,,160);
+        PlaySound(BoostReadySound, SLOT_Misc, 128,,,);
         return false;
     }
     return Super.KDriverLeave(bForceLeave);


### PR DESCRIPTION
I don't know what these numbers do but I do know they are the cause of the sound not being right in 32 bit, without this number it sounds right in both 32 & 64 bit now