### PR TITLE
UT3 Leviathan Turret Pitch Closer to UT3

### DIFF
--- a/Classes/UT3LeviathanTurretWeapon.uc
+++ b/Classes/UT3LeviathanTurretWeapon.uc
@@ -160,4 +160,5 @@ defaultproperties
 
     WeaponFireOffset     = 40.0
     ShieldAttachmentBone = Object84
+    PitchDownLimit=55000
 }


### PR DESCRIPTION
Closer to UT3 but not exact on purpose because of the turrets clipping and also causing camera issues, in UT3 the turrets can look nearly all the way down and pitch back up automatically at a certain collision point which doesn't happen with UT2004 so we need to limit it a little, the default stock Levi turret's pitch is too limited