### PR TITLE
Update UT3ScorpionTurret.uc

### DIFF
--- a/Classes/UT3ScorpionTurret.uc
+++ b/Classes/UT3ScorpionTurret.uc
@@ -66,4 +66,6 @@ defaultproperties
     TeamProjectileClasses(1)=class'UT3ScorpionBallBlue'
     FireSoundClass=Sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_AltFire01'
     AIInfo(0)=(aimerror=650.000000,bTrySplash=True,bLeadTarget=True)
+    PitchUpLimit=9600
+    PitchDownLimit=60000
 }


### PR DESCRIPTION
In UT3 Scorpion can't aim straight up, it does have a limit point however it is higher than we can get without clipping and seeing inside or through the Scorpion so this sets it as close as we can get without clipping which is slightly less by maybe 1000-3000 it's not too far off.