### PR TITLE
Update UT3HellbenderSideGun.uc

### DIFF
--- a/Classes/UT3DmgType_HellbenderLaser.uc
+++ b/Classes/UT3DmgType_HellbenderLaser.uc
@@ -4,7 +4,7 @@ class UT3DmgType_HellbenderLaser extends DamTypePRVLaser
 defaultproperties
 {
     VehicleClass=Class'UT3Hellbender'
-    DeathString="%k's laser shocked %o."
+    DeathString="%k's Hellbender laser shocked %o."
     FemaleSuicide="%o used her laser on herself."
     MaleSuicide="%o used his laser on himself."
     KDamageImpulse=2000

--- a/Classes/UT3DmgType_HellbenderLaser.uc
+++ b/Classes/UT3DmgType_HellbenderLaser.uc
@@ -1,3 +1,43 @@
+/*
+ * Copyright © 2018 GreatEmerald
+ * Copyright © 2018 HellDragon
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     (1) Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *     (2) Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *     (3) The name of the author may not be used to
+ *     endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *     (4) The use, modification and redistribution of this software must
+ *     be made in compliance with the additional terms and restrictions
+ *     provided by the Unreal Tournament 2004 End User License Agreement.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software is not supported by Atari, S.A., Epic Games, Inc. or any
+ * of such parties' affiliates and subsidiaries.
+ */
+
 class UT3DmgType_HellbenderLaser extends DamTypePRVLaser
 	abstract;
 

--- a/Classes/UT3DmgType_HellbenderLaser.uc
+++ b/Classes/UT3DmgType_HellbenderLaser.uc
@@ -4,8 +4,8 @@ class UT3DmgType_HellbenderLaser extends DamTypePRVLaser
 defaultproperties
 {
     VehicleClass=Class'UT3Hellbender'
-    DeathString="%o was disintegrated by %k's Hellbender laser beam."
-    FemaleSuicide="%o somehow managed to disintegrate herself with a laser beam."
-    MaleSuicide="%o somehow managed to disintegrate himself with a laser beam."
+    DeathString="%k's laser shocked %o."
+    FemaleSuicide="%o used her laser on herself."
+    MaleSuicide="%o used his laser on himself."
     KDamageImpulse=2000
 }

--- a/Classes/UT3DmgType_HellbenderLaser.uc
+++ b/Classes/UT3DmgType_HellbenderLaser.uc
@@ -1,0 +1,11 @@
+class UT3DmgType_HellbenderLaser extends DamTypePRVLaser
+	abstract;
+
+defaultproperties
+{
+    VehicleClass=Class'UT3Hellbender'
+    DeathString="%o was disintegrated by %k's Hellbender laser beam."
+    FemaleSuicide="%o somehow managed to disintegrate herself with a laser beam."
+    MaleSuicide="%o somehow managed to disintegrate himself with a laser beam."
+    KDamageImpulse=2000
+}

--- a/Classes/UT3HellbenderSideGun.uc
+++ b/Classes/UT3HellbenderSideGun.uc
@@ -41,8 +41,9 @@ class UT3HellbenderSideGun extends ONSPRVSideGun;
 
 defaultproperties
 {
+
+    DrawScale = 1.0
     Mesh = SkeletalMesh'UT3VH_Hellbender_Anims.HellbenderSecondaryTurret'
-    //DrawScale = 1.0
     RedSkin = Shader'UT3HellbenderTex.UT3HellbenderSkinRed'
     BlueSkin = Shader'UT3HellbenderTex.UT3HellbenderSkinBlue'
     PitchBone=SecondaryTurretPitch

--- a/Classes/UT3HellbenderSideGun.uc
+++ b/Classes/UT3HellbenderSideGun.uc
@@ -42,12 +42,13 @@ class UT3HellbenderSideGun extends ONSPRVSideGun;
 defaultproperties
 {
     Mesh = SkeletalMesh'UT3VH_Hellbender_Anims.HellbenderSecondaryTurret'
-    DrawScale = 1.0
+    //DrawScale = 1.0
     RedSkin = Shader'UT3HellbenderTex.UT3HellbenderSkinRed'
     BlueSkin = Shader'UT3HellbenderTex.UT3HellbenderSkinBlue'
     PitchBone=SecondaryTurretPitch
     YawBone=SecondaryTurretYaw
     WeaponFireAttachmentBone=SecondaryTurretBarrel
+    DamageType=class'UT3DmgType_HellbenderLaser'
     FireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BallFire01'
     AltFireSoundClass = Sound'UT3A_Vehicle_Hellbender.Sounds.A_Vehicle_Hellbender_BeamFire01'
     PitchUpLimit=9600  //16000 is about what UT3 is but we don't have UT3's camera collision meaning we see under and through the Hellbender in UT2004


### PR DESCRIPTION
Drawscale disabled in code to not double with ukx & death message fix kind of

EDIT - Ah got it wrong, apparently SPMA and Hellbender turrets are not the same on message?

[UTDmgType_VehicleShockBeam]   - This is Hellbender as far as I can tell
DeathString="`k's laser shocked `o."
MaleSuicide="`o used his laser on himself."
FemaleSuicide="`o used her laser on herself."

[UTDmgType_SPMAShockBeam]
DeathString="`o was disintegrated by `k's beam."
MaleSuicide="`o disintegrated himself."
FemaleSuicide="`o disintegrated herself."