### PR TITLE
Update UT3LeviathanTurretWeapon.uc

### DIFF
--- a/Classes/UT3LeviathanTurretWeapon.uc
+++ b/Classes/UT3LeviathanTurretWeapon.uc
@@ -1,6 +1,7 @@
 /*
  * Copyright © 2007 Wormbo
  * Copyright © 2014 GreatEmerald
+ * Copyright © 2017 HellDragon
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -161,4 +162,5 @@ defaultproperties
     WeaponFireOffset     = 40.0
     ShieldAttachmentBone = Object84
     PitchDownLimit=55000
+    PitchUpLimit=12000
 }


### PR DESCRIPTION
Set a limit of upward aim to help with camera issues, in UT3 turrets can (or seem to) aim straight up, this sets it just a little less where they can almost aim straight up but not quite