### PR TITLE
Nightshade patch

### DIFF
--- a/Classes/UT3DmgType_NightshadeBeam.uc
+++ b/Classes/UT3DmgType_NightshadeBeam.uc
@@ -1,6 +1,5 @@
 /*
- * Copyright © 2012 100GPing100
- * Copyright © 2014 GreatEmerald
+ * Copyright © 2017 Luís 'zeluisping' Guimarães (100GPing100)
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -47,7 +46,7 @@ DefaultProperties
 	MaleSuicide="%o shafted himself.";
 	FemaleSuicide="%o shafted herself.";
 
-	WeaponClass=class'Weap_UT3Nightshade';
+	WeaponClass=class'UT3Weap_NightshadeBeam';
 
 	bDetonatesGoop=true
     bCausesBlood=false

--- a/Classes/UT3DmgType_NightshadeBeam.uc
+++ b/Classes/UT3DmgType_NightshadeBeam.uc
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2012 100GPing100
+ * Copyright © 2014 GreatEmerald
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     (1) Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *     (2) Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *     (3) The name of the author may not be used to
+ *     endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *     (4) The use, modification and redistribution of this software must
+ *     be made in compliance with the additional terms and restrictions
+ *     provided by the Unreal Tournament 2004 End User License Agreement.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software is not supported by Atari, S.A., Epic Games, Inc. or any
+ * of such parties' affiliates and subsidiaries.
+ */
+
+class UT3DmgType_NightshadeBeam extends WeaponDamageType
+	abstract;
+
+DefaultProperties
+{
+	DeathString="%o was carved up by %k's Nightshade shaft.";
+	MaleSuicide="%o shafted himself.";
+	FemaleSuicide="%o shafted herself.";
+
+	WeaponClass=class'Weap_UT3Nightshade';
+
+	bDetonatesGoop=true
+    bCausesBlood=false
+	bLeaveBodyEffect=true
+	bSkeletize=true
+
+    //DamageOverlayMaterial=Material'XGameShaders.PlayerShaders.LinkHit'
+    //DamageOverlayTime=0.5
+
+	//DeathOverlayMaterial=Material'XGameShaders.PlayerShaders.LinkHit'
+    //DeathOverlayTime=1.0
+
+	VehicleMomentumScaling=0.1;
+	VehicleDamageScaling=0.8;
+
+	KDamageImpulse=100
+}

--- a/Classes/UT3Nightshade.uc
+++ b/Classes/UT3Nightshade.uc
@@ -283,7 +283,10 @@ function Tick(float DeltaTime)
 	CheckState();
 
 	if (CurrentState == VS_Deployed && PlayerController(Controller) != none) {
-		ShoulderRotation.Yaw = (Rotation - Controller.Rotation).Yaw % 65536; // make it [0;65536]
+		ShoulderRotation.Yaw = (Rotation - Controller.Rotation).Yaw % 65536;
+		if (ShoulderRotation.Yaw < 0) {
+			ShoulderRotation.Yaw += 65536;
+		}
 
 		if (ShoulderRotation.Yaw <= 32768 && ShoulderRotation.Yaw > 8192) {
 			ShoulderRotation.Yaw = 8192;

--- a/Classes/UT3Nightshade.uc
+++ b/Classes/UT3Nightshade.uc
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2012 100GPing100
- * Copyright © 2014 GreatEmerald
+ * Copyright ï¿½ 2012 100GPing100
+ * Copyright ï¿½ 2014 GreatEmerald
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -156,7 +156,7 @@ function bool NoObstacle()
 	else
 		return false;
 }
-/* » Type:
+/* ï¿½ Type:
  * 0: General message.
  * 1: Mine select message.
 */
@@ -514,7 +514,7 @@ simulated function PrevWeapon()
 }
 simulated function SwitchWeapon(byte F)
 {
-	if (F == SelectedMine)
+	if (F == SelectedMine || CurrentState != VS_Deployed)
 		return;
 	switch (F)
 	{

--- a/Classes/UT3Nightshade.uc
+++ b/Classes/UT3Nightshade.uc
@@ -922,6 +922,8 @@ DefaultProperties
 	MineObjectClasses(1) = class'UT3StasisFieldObject';
 	MineObjectClasses(2) = class'UT3EMPObject';
 	MineObjectClasses(3) = class'UT3ShieldObject';
+	BikeDustOffset=();
+	BikeDustOffset(0)=(X=25,Y=0,Z=10)
 
 	// HUD.
 	bShowChargingBar = false;

--- a/Classes/UT3Nightshade.uc
+++ b/Classes/UT3Nightshade.uc
@@ -100,6 +100,13 @@ var vector DeployedTPCamLookat;
 
 
 
+simulated function Destroyed() {
+	super.Destroyed();
+
+	if (ArmMine != none) {
+		ArmMine.Destroy();
+	}
+}
 simulated function bool SpecialCalcView(out actor ViewActor, out vector CameraLocation, out rotator CameraRotation)
 {
 	local PlayerController PC;

--- a/Classes/UT3Nightshade.uc
+++ b/Classes/UT3Nightshade.uc
@@ -1,5 +1,5 @@
 /*
- * Copyright � 2012 100GPing100
+ * Copyright � 2012, 2017 Luís 'zeluisping' Guimarães (100GPing100)
  * Copyright � 2014 GreatEmerald
  *
  * Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ class UT3Nightshade extends ONSHoverBike;
 // Load packages.
 #exec obj load file=../Textures/UT3NightShadeTex.utx
 #exec obj load file=../Animations/UT3NightShadeAnims.ukx
+#exec obj load file=../Sounds/UT3A_Vehicle_Nightshade.uax
 
 
 /* The ammount of normal speed to have when cloaked. */
@@ -954,7 +955,7 @@ DefaultProperties
 
 	// Damage.
 	//DriverWeapons(0) = (WeaponClass=Class'Onslaught.ONSHoverBikePlasmaGun',WeaponBone="Turret_Pitch")
-	DriverWeapons(0) = (WeaponClass=Class'Weap_UT3Nightshade',WeaponBone="Base");
+	DriverWeapons(0) = (WeaponClass=Class'UT3Weap_NightshadeBeam',WeaponBone="Base");
 	Health = 600;
 	HealthMax = 600;
 	MeleeRange = -100;

--- a/Classes/UT3Weap_NightshadeBeam.uc
+++ b/Classes/UT3Weap_NightshadeBeam.uc
@@ -1,5 +1,5 @@
 /*
- * Copyright � 2012 100GPing100
+ * Copyright � 2012, 2017 Luís 'zeluisping' Guimarães (100GPing100)
  * Copyright � 2014 GreatEmerald
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,7 @@
  * of such parties' affiliates and subsidiaries.
  */
 
-class Weap_UT3Nightshade extends ONSWeapon;
+class UT3Weap_NightshadeBeam extends ONSWeapon;
 
 
 /* The beam effect. */

--- a/Classes/Weap_UT3Nightshade.uc
+++ b/Classes/Weap_UT3Nightshade.uc
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2012 100GPing100
- * Copyright © 2014 GreatEmerald
+ * Copyright ï¿½ 2012 100GPing100
+ * Copyright ï¿½ 2014 GreatEmerald
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -260,6 +260,7 @@ DefaultProperties
 	Momentum = 50000.0;
 	Damage = 120;
 	MinimumDamage = 5.0;
+	DamageType = Class'UT3DmgType_NightshadeBeam';
 
 	// Sound.
 	FireStart = Sound'UT3A_Vehicle_Nightshade.Sounds.A_Vehicle_Nightshade_FireStart01';


### PR DESCRIPTION
Here's a list of changes:
- Can no longer change mine while deploying/undeploying
- Forced and new third person view while deployed
- Arm rotation while deployed
- State changing code improved
- Beam damage type (fixes the bullet hit sound bug)
- Added dust/water effects while uncloaked
- Renamed `Weap_UT3Nightshade` to `UT3Weap_NightshadeBeam`
- Beam gun no longer rotates while deployed

Fixed from #10:
- [X] ~~Pressing jump button enters deploy mode which does work but doesn't seem you can aim like it is in UT3 (side to side)~~
- [X] ~~While not invisible on UT3 it has Manta like dust blow under it, not in UT2004 though~~

Fixed from #125:
- [X] ~~Impact sound of beam weapon is bullet impact sounds in UT2004, doesn't seem to really have an impact sound in UT3 that I can hear~~