### PR TITLE
Manta: Fix typo

### DIFF
--- a/Classes/UT3Manta.uc
+++ b/Classes/UT3Manta.uc
@@ -114,7 +114,7 @@ function ToggleBlades(bool bRotating)
         // Off.
         Blades[0].Skins[0] = Blades[0].BladesOffTex;
         Blades[1].Skins[0] = Blades[1].BladesOffTex;
-    0}
+    }
 }
 
 //


### PR DESCRIPTION
This fixes the typo from the last manta patch, as was pointed out by @Unre-Alex on commit c821c3e.