### PR TITLE
Manta: Gun Barrel Movement

### DIFF
--- a/Classes/UT3Manta.uc
+++ b/Classes/UT3Manta.uc
@@ -122,8 +122,10 @@ function ToggleBlades(bool bRotating)
 //
 function Ailerons(float DeltaTime)
 {
-    // 45° = 8192 RUU
     local Rotator AileronsRotation;
+    Super.Tick(DeltaTime);
+    Guns();
+    // 45° = 8192 RUU
 
     // 1000 = The velocity at wich the angle is of 45º
     AileronsRotation.Pitch = 8192 * (Velocity.Z / 1000) - Rotation.Pitch;
@@ -146,6 +148,19 @@ function Destroyed()
     Blades[1].Destroy();
 
     Super.Destroyed();
+}
+
+// Animates the guns depending on the driver's view.
+//
+function Guns()
+{
+    local Rotator GunsRotation;
+
+    GunsRotation.Pitch = -DriverViewPitch;
+    //GunsRotation.Yaw = -DriverViewYaw;
+	
+    SetBoneRotation('Barrel_rt', GunsRotation, 0, 1);
+    SetBoneRotation('Barrel_lt', GunsRotation, 0, 1);
 }
 
 simulated function CheckJumpDuck()

--- a/Classes/UT3Manta.uc
+++ b/Classes/UT3Manta.uc
@@ -123,8 +123,8 @@ function ToggleBlades(bool bRotating)
 function Ailerons(float DeltaTime)
 {
     local Rotator AileronsRotation;
+    local Rotator GunsRotation;
     Super.Tick(DeltaTime);
-    Guns();
     // 45° = 8192 RUU
 
     // 1000 = The velocity at wich the angle is of 45º
@@ -137,6 +137,12 @@ function Ailerons(float DeltaTime)
 
     SetBoneRotation('Aileron_Rt', AileronsRotation, 0, 1);
     SetBoneRotation('Aileron_Lt', AileronsRotation, 0, 1);
+    
+    GunsRotation.Pitch = -DriverViewPitch;
+    //GunsRotation.Yaw = -DriverViewYaw;
+    
+    SetBoneRotation('Barrel_rt', GunsRotation, 0, 1);
+    SetBoneRotation('Barrel_lt', GunsRotation, 0, 1);
 }
 
 //
@@ -148,19 +154,6 @@ function Destroyed()
     Blades[1].Destroy();
 
     Super.Destroyed();
-}
-
-// Animates the guns depending on the driver's view.
-//
-function Guns()
-{
-    local Rotator GunsRotation;
-
-    GunsRotation.Pitch = -DriverViewPitch;
-    //GunsRotation.Yaw = -DriverViewYaw;
-	
-    SetBoneRotation('Barrel_rt', GunsRotation, 0, 1);
-    SetBoneRotation('Barrel_lt', GunsRotation, 0, 1);
 }
 
 simulated function CheckJumpDuck()


### PR DESCRIPTION
Somewhere we lost the movement on the guns or perhaps I just missed adding it to the over all but this should restore it, it compiles and works in-game for me but it would be nice if someone could double check.