### PR TITLE
Hoverboard: Fix missing references

### DIFF
--- a/Classes/UT3Hoverboard.uc
+++ b/Classes/UT3Hoverboard.uc
@@ -45,9 +45,9 @@
 //#exec MESH  MODELIMPORT MESH=TankVictimMesh MODELFILE=models\tank_victim.PSK RIGID=1
 
 
-#exec OBJ LOAD FILE=StaticMeshes\EONSLocustSM.usx
-#exec OBJ LOAD FILE=Animations\EONSLocustA.ukx
-#exec OBJ LOAD FILE=Textures\EONSLocustTex.utx
+#exec OBJ LOAD FILE=..\StaticMeshes\EONSLocustSM.usx
+#exec OBJ LOAD FILE=..\Animations\EONSLocustA.ukx
+#exec OBJ LOAD FILE=..\Textures\EONSLocustTex.utx
 
 #exec OBJ LOAD FILE=..\Sounds\ONSVehicleSounds-S.uax
 #exec OBJ LOAD FILE=..\textures\EpicParticles.utx


### PR DESCRIPTION
Bad path in https://github.com/GreatEmerald/UT3Vehicles/blob/f8c45fe389fd190439c17e5f03ce1e6e207fa23a/Classes/UT3Hoverboard.uc#L48-L50

This fixes errors in references such as:
https://github.com/GreatEmerald/UT3Vehicles/blob/f8c45fe389fd190439c17e5f03ce1e6e207fa23a/Classes/UT3Hoverboard.uc#L838

Fixes errors as:
`Z:\home\ping\UT2004\UT3Vehicles\Classes\UT3Hoverboard.uc(838) : Error, Can't find StaticMesh '`