### PR TITLE
Fix Hellbender Driver Death Message & Reupload Missing Dmg Types

### DIFF
--- a/Classes/UT3DmgType_HellbenderCombo.uc
+++ b/Classes/UT3DmgType_HellbenderCombo.uc
@@ -1,3 +1,43 @@
+/*
+ * Copyright © 2017 GreatEmerald
+ * Copyright © 2017-2018 HellDragon
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     (1) Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *     (2) Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *     (3) The name of the author may not be used to
+ *     endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *     (4) The use, modification and redistribution of this software must
+ *     be made in compliance with the additional terms and restrictions
+ *     provided by the Unreal Tournament 2004 End User License Agreement.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software is not supported by Atari, S.A., Epic Games, Inc. or any
+ * of such parties' affiliates and subsidiaries.
+ */
+
 class UT3DmgType_HellbenderCombo extends DamTypePRVCombo
 	abstract;
 

--- a/Classes/UT3DmgType_HellbenderCombo.uc
+++ b/Classes/UT3DmgType_HellbenderCombo.uc
@@ -1,0 +1,11 @@
+class UT3DmgType_HellbenderCombo extends DamTypePRVCombo
+	abstract;
+
+defaultproperties
+{
+    VehicleClass=Class'UT3Hellbender'
+    KDamageImpulse=2000
+    VehicleMomentumScaling=1.5
+    VehicleDamageScaling=+1.0
+
+}

--- a/Classes/UT3DmgType_HellbenderLaser.uc
+++ b/Classes/UT3DmgType_HellbenderLaser.uc
@@ -44,7 +44,7 @@ class UT3DmgType_HellbenderLaser extends DamTypePRVLaser
 defaultproperties
 {
     VehicleClass=Class'UT3Hellbender'
-    DeathString="%k's Hellbender laser shocked %o."
+    DeathString="%k's laser shocked %o."
     FemaleSuicide="%o used her laser on herself."
     MaleSuicide="%o used his laser on himself."
     KDamageImpulse=2000

--- a/Classes/UT3DmgType_ScorpionBlades.uc
+++ b/Classes/UT3DmgType_ScorpionBlades.uc
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014 GreatEmerald
+ * Copyright © 2017-2018 HellDragon
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     (1) Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *     (2) Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimers in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *     (3) The name of the author may not be used to
+ *     endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ *     (4) The use, modification and redistribution of this software must
+ *     be made in compliance with the additional terms and restrictions
+ *     provided by the Unreal Tournament 2004 End User License Agreement.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software is not supported by Atari, S.A., Epic Games, Inc. or any
+ * of such parties' affiliates and subsidiaries.
+ */
+
+class UT3DmgType_ScorpionBlades extends DamTypeONSRVBlade;
+
+defaultproperties
+{
+    DeathString="%o was cut down by %k's blades."
+    VehicleClass=class'UT3Scorpion'
+}


### PR DESCRIPTION
Death message closer to UT3 now, main reason of this was to upload the apparently missing Hellbender Combo class