### PR TITLE
Manta: Smoke & Fire Locations WIP, Help Needed

### DIFF
--- a/Classes/UT3Manta.uc
+++ b/Classes/UT3Manta.uc
@@ -50,6 +50,11 @@ var Emitter DuckEffect;
 #exec obj load file=../Textures/UT3MantaTex.utx
 #exec obj load file=../Sounds/UT3A_Vehicle_Manta.uax
 
+var  	array<ONSDamagedEffect>     DamagedEffect;
+var()	array<vector>               DamagedEffectOffset;
+var()	class<ONSDamagedEffect>     DamagedEffectClass;
+var()	float						DamagedEffectScale;
+
 /* The spining blades. */
 var array<UT3MantaBlade> Blades;
 
@@ -376,6 +381,15 @@ defaultproperties
     //TPCamDistance=300.000000
     //TPCamLookat=(X=0,Y=0,Z=0)
     //TPCamWorldOffset=(X=0,Y=0,Z=35)
+
+	DamagedEffectClass=()
+    DamagedEffectClass(0)=class'ONSDamagedEffect'
+	DamagedEffectClass(1)=class'ONSDamagedEffect'
+	
+	DamagedEffectOffset=()
+	DamagedEffectOffset(0)=(X=2,Y=31,Z=16)    //Right Turbine fire point
+	DamagedEffectOffset(1)=(X=2,Y=-75,Z=-10)  //Left Blades fire point
+	DamagedEffectScale=0.6
 
     HeadlightCoronaOffset=()
     HeadlightCoronaOffset(0)=(X=40.0,Y=0.0,Z=-30.0)


### PR DESCRIPTION
DO NOT MERGE

I've been trying to add the 2nd smoke & fire location as well as set up being able to use a new UT3 visual class later on, so far no luck on getting a 2nd one though.

C:\Unreal Anthology\UT2004\UT3Vehicles\Classes\UT3Manta.uc(67) : Warning, 'DamagedEffect' obscures 'DamagedEffect' defined in base class 'ONSVehicle'.
C:\Unreal Anthology\UT2004\UT3Vehicles\Classes\UT3Manta.uc(68) : Warning, 'DamagedEffectOffset' obscures 'DamagedEffectOffset' defined in base class 'ONSVehicle'.
C:\Unreal Anthology\UT2004\UT3Vehicles\Classes\UT3Manta.uc(69) : Warning, 'DamagedEffectClass' obscures 'DamagedEffectClass' defined in base class 'ONSVehicle'.
C:\Unreal Anthology\UT2004\UT3Vehicles\Classes\UT3Manta.uc(70) : Warning, 'DamagedEffectScale' obscures 'DamagedEffectScale' defined in base class 'ONSVehicle'.

ClassProperty UT3Vehicles.UT3Manta.DamagedEffectClass: unresolved reference to '()'
UT3Vehicles.UT3Manta: Out of bound array default property (1/1)