### PR TITLE
Scorpion: Suspension Tweaks for Turn Bouncing

### DIFF
--- a/Classes/UT3Scorpion.uc
+++ b/Classes/UT3Scorpion.uc
@@ -724,6 +724,9 @@ defaultproperties
     EngineInertia=0.008
     WheelInertia=0.008
     WheelSuspensionOffset=3.0
+    WheelSoftness=0.045  //.025
+    WheelSuspensionTravel=35.0  //15
+    WheelSuspensionMaxRenderTravel=35.0  //15
     bHasHandBrake=False //GE: Override for the space bar?
     BoostSound=Sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_EjectReadyBeepThrustStartMix'
     //BoostSound=Sound'UT3A_Vehicle_Scorpion.Sounds.A_Vehicle_Scorpion_EjectReadyBeep'


### PR DESCRIPTION
In UT3 the Scorpion has a lot of bounce when turning, and I think these changes to the suspensions get it closer to that, needs some testing still to ensure it's playable without problems though,  you up for it @Unre-Alex ?

Also do me a favor and keep in mind other ground vehicles probably need some tweaking too, so let me know about that if you can now that I know how, I suspect the Hellbender and Paladin still need some.